### PR TITLE
Refactor: materialized views

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright {yyyy} {name of copyright owner}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,91 +1,25 @@
 # dbt Labs: Experimental Features
 
-This package will add dbt support for database features which are not
-yet supported natively in dbt-core.
+This repository includes projects that extend of existing dbt features, experiment with new database features not yet natively supported in dbt, or otherwise demonstrate cool stuff you can do with just Jinja macros in your project—no forks necessary.
 
-### Installation
+In all cases, these are _demo_ projects, not intended as ready-to-use packages. If you want to use code from this repository in your own project, you're more than welcome to clone and install as a [local package](https://docs.getdbt.com/docs/building-a-dbt-project/package-management/#local-packages), or just copy-paste :)
 
-This repository contains multiple dbt projects. To use the code from one in your
-own project, clone the repo and install it [locally](https://docs.getdbt.com/docs/building-a-dbt-project/package-management/#local-packages), e.g.:
-
-```
-packages:
-  - local: /Users/you/dbt-labs-experimental-features/materialized-views
-```
-
-## BigQuery Incremental Strategies
+## [BigQuery Incremental Strategies](bq-incrementals)
 
 * These features shipped in dbt v0.16.0! See [changelog](https://github.com/fishtown-analytics/dbt/blob/dev/octavius-catto/CHANGELOG.md#features-4) and [docs](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/bigquery-configs/#merge-behavior-incremental-models)
 * The [project here](bq_incrementals) provided the substrate for a [discourse post](https://discourse.getdbt.com/t/981) benchmarking different incremental strategies on BigQuery
 
-## Materialized views
+## [Materialized views](materialized-views)
 
-This package adds support for `materialized_view` as a dbt materialization. It takes an
-approach similar to that of the existing `incremental` materialization:
-- In a "full refresh" run, drop and recreate the MV from scratch.
-- Otherwise, "refresh" the MV as appropriate. Depending on the database, that could be DML (`refresh`) or noop.
+This project adds support for `materialized_view` as a new dbt materialization. It includes implementations for Postgres, Redshift, Snowflake, and BigQuery, through a mix of new macros and overrides of built-in dbt macros. See the [project README](materialized-views/README.md) for details. For another take on dbt + materialized views, check out the [dbt-materialize](https://github.com/MaterializeInc/dbt-materialize) plugin.
 
-At any point, if the database object corresponding to a MV model exists instead as a table
-or standard view, dbt will attempt to drop it and recreate the model from scratch as a
-materialized view.
-
-#### Postgres
-
-- Supported model configs: none
-- [docs](https://www.postgresql.org/docs/9.3/rules-materializedviews.html)
-
-##### Current issues
-- Materialized views are registered in `pg_matviews`. Because dbt's current caching
-only checks `pg_tables` and `pg_views` for existing relations, the current approach is to work around
-the cache and check `pg_matviews` from within the materialization.
-- dbt only allows 'materializedview' as a `RelationType`. (See [here](https://github.com/fishtown-analytics/dbt/blob/dev/octavius-catto/core/dbt/adapters/base/relation.py#L24)). When we try to use
-`adapter.rename` or `adapter.drop`, the database is expecting `drop materialized view ...` or `alter materialized view ... rename`,
-not `drop materializedview ...` or `alter materializedview ... rename`.
-
-#### Redshift
-
-- Supported model configs: `sort`, `dist`
-- [docs](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html)
-- Anecdotally, `refresh materialized view ...` is _very_ slow to run
-
-##### Current issues
-- MVs do not support late binding. If the base table is cascade dropped, the materialized view seems to stick around in the cache. We need
-some way to "hard refresh" the cache or check the database after running parents.
-- If the column is renamed or removed + readded (e.g. varchar widening), the materialized view cannot be refreshed.
-```
-Database Error in model test_mv (models/test_mv.sql)
-  Materialized view test_mv is unrefreshable as a column was renamed for a base table.
-  compiled SQL at target/run/dbt_labs_experimental_features_integration_tests/test_mv.sql
-```
-
-#### BigQuery
-
-- Supported model configs: `enable_refresh`, `refresh_interval_minutes`
-- [docs](https://cloud.google.com/bigquery/docs/materialized-views-intro)
-- Although BQ does not have `drop ... cascade`, if the base table of a MV is dropped
-and recreated, the MV also needs to be dropped and recreated
-```
-Materialized view dbt-dev-168022:dbt_jcohen.test_mv references table dbt-dev-168022:dbt_jcohen.base_tbl which was deleted and recreated. The view must be deleted and recreated as well.
-```
-
-#### Snowflake
-
-- Supported model configs: `secure`, `cluster_by`, `automatic_clustering`, `persist_docs` (relation only)
-- [docs](https://docs.snowflake.com/en/user-guide/views-materialized.html)
-- Note: Snowflake MVs are only enabled on enterprise accounts
-- Although Snowflake does not have `drop ... cascade`, if the base table table of a MV is dropped
-and recreated, the MV also needs to be dropped and recreated, otherwise the following error will appear:
-```
-Failure during expansion of view 'TEST_MV': SQL compilation error: Materialized View TEST_MV is invalid.
-```
-
-## Lambda views
+## [Lambda views](lambda-views)
 This lab demonstrates a number of options for lambda views, as discussed in this [discourse article](https://discourse.getdbt.com/t/how-to-create-near-real-time-models-with-just-dbt-sql/1457/3). Additional details about the various approaches can be found in at [lambda-views/README.md](lambda-views/README.md).
 
-## Snapshot testing
+## [Snapshot testing](snapshot-testing)
 This lab demonstrates how to use snapshots to detect dbt model regressions, as discussed in this [discourse article](https://discourse.getdbt.com/t/build-snapshot-based-tests-to-detect-regressions-in-historic-data/1478). Additional details on how to test this code for yourself can be found at [snapshot-testing/README.md](snapshot-testing/README.md).
 
-## dynamic-data-masking-redshift
+## [Dynamic data masking on Redshift](dynamic-data-masking-redshift)
 This labs demonstrates how to implement dynamic data masking on Redshift.
 
 Check out [this discourse article](https://discourse.getdbt.com/t/how-to-implement-dynamic-data-masking-on-redshift/2043) for more information.
@@ -93,6 +27,6 @@ Check out [this discourse article](https://discourse.getdbt.com/t/how-to-impleme
 ### Resources:
 - Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
 - Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
-- Join the [chat](http://slack.getdbt.com/) on Slack for live discussions and support
+- Join the [chat](http://community.getdbt.com/) on Slack for live discussions and support
 - Find [dbt events](https://events.getdbt.com) near you
 - Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices

--- a/materialized-views/README.md
+++ b/materialized-views/README.md
@@ -1,3 +1,5 @@
+## dbt_labs_materialized_views
+
 `dbt_labs_materialized_views` is a dbt project containing materializations, helper macros, and some builtin macro overrides that enable use of materialized views in your dbt project. It takes a conceptual approach similar to that of the existing `incremental` materialization:
 - In a "full refresh" run, drop and recreate the MV from scratch.
 - Otherwise, "refresh" the MV as appropriate. Depending on the database, that could require DML (`refresh`) or no action.
@@ -17,6 +19,8 @@ You can:
 The Postgres and Redshift implementations both require overriding the builtin versions of some adapter macros. If you've installed `dbt_labs_materialized_views` as a local package, you can achieve this override by creating a file `macros/*.sql` in your project with the following contents:
 
 ```sql
+{# postgres and redshift #}
+
 {% macro drop_relation(relation) -%}
   {{ return(dbt_labs_materialized_views.drop_relation(relation)) }}
 {% endmacro %}
@@ -29,8 +33,18 @@ The Postgres and Redshift implementations both require overriding the builtin ve
   {{ return(dbt_labs_materialized_views.postgres_get_relations()) }}
 {% endmacro %}
 
+{# redshift only #}
+
 {% macro redshift__list_relations_without_caching(schema_relation) %}
   {{ return(dbt_labs_materialized_views.redshift__list_relations_without_caching(schema_relation)) }}
+{% endmacro %}
+
+{% macro load_relation(relation) %}
+  {% if adapter.type() == 'redshift' %}
+    {{ return(dbt_labs_materialized_views.redshift_load_relation_or_mv(relation)) }}
+  {% else %}
+    {{ return(dbt.load_relation(relation)) }}
+  {% endif %}
 {% endmacro %}
 ```
 
@@ -43,8 +57,8 @@ The Postgres and Redshift implementations both require overriding the builtin ve
 
 - Supported model configs: `sort`, `dist`, `auto_refresh`
 - [docs](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html)
-- Anecdotally, `refresh materialized view ...` is _very_ slow to run
-- ❗❗ MVs do not support late binding, so if an underlying table is cascade-dropped, the MV will be dropped as well. This would be fine, except that MVs don't include their "true" dependencies in `pg_depend`. Instead, a materialized view claims to depend on a table relation called `mv_tbl__[MV_name]__0` (in place of the name of the true underlying table). As such, dbt has no way to know if a MV has been dropped when it cascade-drops the underlying table. (https://github.com/awslabs/amazon-redshift-utils/issues/499)
+- Anecdotally, `refresh materialized view ...` is very slow to run. By contrast, `auto_refresh` runs in the background, with minimal disruption to other workloads, at the risk of some small potential latency.
+- ❗ MVs do not support late binding, so if an underlying table is cascade-dropped, the MV will be dropped as well. This would be fine, except that MVs don't include their "true" dependencies in `pg_depend`. Instead, a materialized view claims to depend on a table relation called `mv_tbl__[MV_name]__0`, in place of the name of the true underlying table (https://github.com/awslabs/amazon-redshift-utils/issues/499). As such, dbt's runtime cache is unable to reliably know if a MV has been dropped when it cascade-drops the underlying table. This package requires an override of `load_relation()` to perform a "hard" check (database query of `stv_mv_info`) every time dbt's cache thinks a `materializedview` relation may already exist.
 - ❗ MVs do appear in `pg_views`, but the only way we can know that they're materialized views is that the `create materialized view` DDL appear in their `definition`, instead of just the SQL without DDL (standard views). There's another Redshift system table, `stv_mv_info`, but it can't effectively be joined with `pg_views` because they're different types of system tables.
 - ❗ If a column in the underlying table renamed, or removed and readded (e.g. varchar widening), the materialized view cannot be refreshed:
 ```
@@ -57,7 +71,7 @@ Database Error in model test_mv (models/test_mv.sql)
 
 - Supported model configs: `auto_refresh`, `refresh_interval_minutes`
 - [docs](https://cloud.google.com/bigquery/docs/materialized-views-intro)
-- ❗ Although BQ does not have `drop ... cascade`, if the base table of a MV is dropped and recreated, the MV also needs to be dropped and recreated
+- ❗ Although BQ does not have `drop ... cascade`, if the base table of a MV is dropped and recreated, the MV also needs to be dropped and recreated:
 ```
 Materialized view dbt-dev-168022:dbt_jcohen.test_mv references table dbt-dev-168022:dbt_jcohen.base_tbl which was deleted and recreated. The view must be deleted and recreated as well.
 ```

--- a/materialized-views/README.md
+++ b/materialized-views/README.md
@@ -41,7 +41,7 @@ The Postgres and Redshift implementations both require overriding the builtin ve
 
 ## Redshift
 
-- Supported model configs: `sort`, `dist`
+- Supported model configs: `sort`, `dist`, `auto_refresh`
 - [docs](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html)
 - Anecdotally, `refresh materialized view ...` is _very_ slow to run
 - ❗❗ MVs do not support late binding, so if an underlying table is cascade-dropped, the MV will be dropped as well. This would be fine, except that MVs don't include their "true" dependencies in `pg_depend`. Instead, a materialized view claims to depend on a table relation called `mv_tbl__[MV_name]__0` (in place of the name of the true underlying table). As such, dbt has no way to know if a MV has been dropped when it cascade-drops the underlying table. (https://github.com/awslabs/amazon-redshift-utils/issues/499)
@@ -55,7 +55,7 @@ Database Error in model test_mv (models/test_mv.sql)
 
 ## BigQuery
 
-- Supported model configs: `enable_refresh`, `refresh_interval_minutes`
+- Supported model configs: `auto_refresh`, `refresh_interval_minutes`
 - [docs](https://cloud.google.com/bigquery/docs/materialized-views-intro)
 - ❗ Although BQ does not have `drop ... cascade`, if the base table of a MV is dropped and recreated, the MV also needs to be dropped and recreated
 ```

--- a/materialized-views/README.md
+++ b/materialized-views/README.md
@@ -1,0 +1,73 @@
+`dbt_labs_materialized_views` is a dbt project containing materializations, helper macros, and some builtin macro overrides that enable use of materialized views in your dbt project. It takes a conceptual approach similar to that of the existing `incremental` materialization:
+- In a "full refresh" run, drop and recreate the MV from scratch.
+- Otherwise, "refresh" the MV as appropriate. Depending on the database, that could require DML (`refresh`) or no action.
+
+At any point, if the database object corresponding to a MV model exists instead as a table or standard view, dbt will attempt to drop it and recreate the model from scratch as a materialized view.
+
+Materialized views vary significantly across databases, as do their current limitations. Be sure to read the documentation for your adapter.
+
+If you're here, you may also like the [dbt-materialize](https://github.com/MaterializeInc/dbt-materialize) plugin, which enables dbt to materialize models as materialized views in [Materialize](https://materialize.io/).
+
+## Setup
+
+You can:
+- Install this project as a local package (as in the [integration tests](integration_tests/packages.yml))
+- Copy-paste the files from `macros/` (specifically `default` and your adapter) into your own project
+
+The Postgres and Redshift implementations both require overriding the builtin versions of some adapter macros. If you've installed `dbt_labs_materialized_views` as a local package, you can achieve this override by creating a file `macros/*.sql` in your project with the following contents:
+
+```sql
+{% macro drop_relation(relation) -%}
+  {{ return(dbt_labs_materialized_views.drop_relation(relation)) }}
+{% endmacro %}
+
+{% macro postgres__list_relations_without_caching(schema_relation) %}
+  {{ return(dbt_labs_materialized_views.postgres__list_relations_without_caching(schema_relation)) }}
+{% endmacro %}
+
+{% macro postgres_get_relations() %}
+  {{ return(dbt_labs_materialized_views.postgres_get_relations()) }}
+{% endmacro %}
+
+{% macro redshift__list_relations_without_caching(schema_relation) %}
+  {{ return(dbt_labs_materialized_views.redshift__list_relations_without_caching(schema_relation)) }}
+{% endmacro %}
+```
+
+## Postgres
+
+- Supported model configs: none
+- [docs](https://www.postgresql.org/docs/9.3/rules-materializedviews.html)
+
+## Redshift
+
+- Supported model configs: `sort`, `dist`
+- [docs](https://docs.aws.amazon.com/redshift/latest/dg/materialized-view-overview.html)
+- Anecdotally, `refresh materialized view ...` is _very_ slow to run
+- ❗❗ MVs do not support late binding, so if an underlying table is cascade-dropped, the MV will be dropped as well. This would be fine, except that MVs don't include their "true" dependencies in `pg_depend`. Instead, a materialized view claims to depend on a table relation called `mv_tbl__[MV_name]__0` (in place of the name of the true underlying table). As such, dbt has no way to know if a MV has been dropped when it cascade-drops the underlying table. (https://github.com/awslabs/amazon-redshift-utils/issues/499)
+- ❗ MVs do appear in `pg_views`, but the only way we can know that they're materialized views is that the `create materialized view` DDL appear in their `definition`, instead of just the SQL without DDL (standard views). There's another Redshift system table, `stv_mv_info`, but it can't effectively be joined with `pg_views` because they're different types of system tables.
+- ❗ If a column in the underlying table renamed, or removed and readded (e.g. varchar widening), the materialized view cannot be refreshed:
+```
+Database Error in model test_mv (models/test_mv.sql)
+  Materialized view test_mv is unrefreshable as a column was renamed for a base table.
+  compiled SQL at target/run/dbt_labs_experimental_features_integration_tests/test_mv.sql
+```
+
+## BigQuery
+
+- Supported model configs: `enable_refresh`, `refresh_interval_minutes`
+- [docs](https://cloud.google.com/bigquery/docs/materialized-views-intro)
+- ❗ Although BQ does not have `drop ... cascade`, if the base table of a MV is dropped and recreated, the MV also needs to be dropped and recreated
+```
+Materialized view dbt-dev-168022:dbt_jcohen.test_mv references table dbt-dev-168022:dbt_jcohen.base_tbl which was deleted and recreated. The view must be deleted and recreated as well.
+```
+
+## Snowflake
+
+- Supported model configs: `secure`, `cluster_by`, `automatic_clustering`, `persist_docs` (relation only)
+- [docs](https://docs.snowflake.com/en/user-guide/views-materialized.html)
+- ❗ Note: Snowflake MVs are only enabled on enterprise accounts
+- ❗ Although Snowflake does not have `drop ... cascade`, if the base table table of a MV is dropped and recreated, the MV also needs to be dropped and recreated, otherwise the following error will appear:
+```
+Failure during expansion of view 'TEST_MV': SQL compilation error: Materialized View TEST_MV is invalid.
+```

--- a/materialized-views/dbt_project.yml
+++ b/materialized-views/dbt_project.yml
@@ -1,5 +1,7 @@
-name: 'dbt_labs_experimental_features'
-version: '0.1.0'
+name: 'dbt_labs_materialized_views'
+version: '0.2.0'
+config-version: 2
+require-dbt-version: ">=0.18.0"
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]

--- a/materialized-views/integration_tests/Makefile
+++ b/materialized-views/integration_tests/Makefile
@@ -14,10 +14,10 @@ test-redshift:
 
 test-snowflake:
 	dbt deps
-	dbt seed --target snowflake --full-refresh
-	dbt run --target snowflake --full-refresh --vars 'update: false'
-	dbt run --target snowflake --vars 'update: true'
-	dbt test --target snowflake
+	dbt seed --profile garage-snowflake --full-refresh
+	dbt run --profile garage-snowflake --full-refresh --vars 'update: false'
+	dbt run --profile garage-snowflake --vars 'update: true'
+	dbt test --profile garage-snowflake
 
 test-bigquery:
 	dbt deps

--- a/materialized-views/integration_tests/Makefile
+++ b/materialized-views/integration_tests/Makefile
@@ -10,6 +10,7 @@ test-redshift:
 	dbt seed --target redshift --full-refresh
 	dbt run --target redshift --full-refresh --vars 'update: false'
 	dbt run --target redshift --vars 'update: true'
+	sleep 10	# wait for auto refresh
 	dbt test --target redshift
 
 test-snowflake:

--- a/materialized-views/integration_tests/dbt_project.yml
+++ b/materialized-views/integration_tests/dbt_project.yml
@@ -1,6 +1,7 @@
 
-name: 'dbt_labs_experimental_features_integration_tests'
-version: '0.1.0'
+name: 'dbt_labs_materialized_views_integration_tests'
+version: '0.2.0'
+config-version: 2
 
 profile: 'integration_tests'
 

--- a/materialized-views/integration_tests/macros/overrides.sql
+++ b/materialized-views/integration_tests/macros/overrides.sql
@@ -1,0 +1,15 @@
+{% macro drop_relation(relation) -%}
+  {{ return(dbt_labs_materialized_views.drop_relation(relation)) }}
+{% endmacro %}
+
+{% macro postgres__list_relations_without_caching(schema_relation) %}
+  {{ return(dbt_labs_materialized_views.postgres__list_relations_without_caching(schema_relation)) }}
+{% endmacro %}
+
+{% macro postgres_get_relations() %}
+  {{ return(dbt_labs_materialized_views.postgres_get_relations()) }}
+{% endmacro %}
+
+{% macro redshift__list_relations_without_caching(schema_relation) %}
+  {{ return(dbt_labs_materialized_views.redshift__list_relations_without_caching(schema_relation)) }}
+{% endmacro %}

--- a/materialized-views/integration_tests/macros/overrides.sql
+++ b/materialized-views/integration_tests/macros/overrides.sql
@@ -1,3 +1,5 @@
+{# postgres + redshift #}
+
 {% macro drop_relation(relation) -%}
   {{ return(dbt_labs_materialized_views.drop_relation(relation)) }}
 {% endmacro %}
@@ -10,6 +12,16 @@
   {{ return(dbt_labs_materialized_views.postgres_get_relations()) }}
 {% endmacro %}
 
+{# redshift only #}
+
 {% macro redshift__list_relations_without_caching(schema_relation) %}
   {{ return(dbt_labs_materialized_views.redshift__list_relations_without_caching(schema_relation)) }}
+{% endmacro %}
+
+{% macro load_relation(relation) %}
+  {% if adapter.type() == 'redshift' %}
+    {{ return(dbt_labs_materialized_views.redshift_load_relation_or_mv(relation)) }}
+  {% else %}
+    {{ return(dbt.load_relation(relation)) }}
+  {% endif %}
 {% endmacro %}

--- a/materialized-views/integration_tests/models/schema.yml
+++ b/materialized-views/integration_tests/models/schema.yml
@@ -1,7 +1,11 @@
 version: 2
 
 models:
-  - name: test_mv
+  - name: test_mv_manual
+    tests:
+      - dbt_utils.equality:
+          compare_model: ref('expected')
+  - name: test_mv_auto
     tests:
       - dbt_utils.equality:
           compare_model: ref('expected')

--- a/materialized-views/integration_tests/models/test_mv_auto.sql
+++ b/materialized-views/integration_tests/models/test_mv_auto.sql
@@ -1,5 +1,6 @@
 {{config(
-    materialized = 'materialized_view'
+    materialized = 'materialized_view',
+    auto_refresh = true
 )}}
 
 select

--- a/materialized-views/integration_tests/models/test_mv_manual.sql
+++ b/materialized-views/integration_tests/models/test_mv_manual.sql
@@ -1,0 +1,12 @@
+{{config(
+    materialized = 'materialized_view',
+    auto_refresh = false
+)}}
+
+select
+
+    gender,
+    count(*) as num
+
+from {{ref('base_tbl')}}
+group by 1

--- a/materialized-views/integration_tests/packages.yml
+++ b/materialized-views/integration_tests/packages.yml
@@ -1,4 +1,4 @@
 packages:
     - local: ../
     - package: fishtown-analytics/dbt_utils
-      version: 0.3.0
+      version: 0.6.4

--- a/materialized-views/macros/bigquery/adapters.sql
+++ b/materialized-views/macros/bigquery/adapters.sql
@@ -10,7 +10,7 @@
 
 {% macro bigquery__create_materialized_view_as(relation, sql, config) -%}
 
-    {%- set enable_refresh = config.get('enable_refresh', none) -%}
+    {%- set enable_refresh = config.get('auto_refresh', none) -%}
     {%- set refresh_interval_minutes = config.get('refresh_interval_minutes', none) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
 
@@ -30,7 +30,7 @@
 
 {% macro bigquery__refresh_materialized_view(relation, config) -%}
     
-    {%- set is_auto_refresh = config.get('enable_refresh', true) %}
+    {%- set is_auto_refresh = config.get('auto_refresh', true) %}
     
     {%- if is_auto_refresh == false -%} {# manual refresh #}
     

--- a/materialized-views/macros/bigquery/adapters.sql
+++ b/materialized-views/macros/bigquery/adapters.sql
@@ -17,7 +17,7 @@
     {{ sql_header if sql_header is not none }}
 
     create materialized view {{relation}}
-    {{ dbt_labs_experimental_features.bigquery_options(
+    {{ dbt_labs_materialized_views.bigquery_options(
         enable_refresh=enable_refresh, 
         refresh_interval_minutes=refresh_interval_minutes
     ) }}

--- a/materialized-views/macros/bigquery/materialized_view.sql
+++ b/materialized-views/macros/bigquery/materialized_view.sql
@@ -1,6 +1,6 @@
 {% materialization materialized_view, adapter='bigquery' -%}
 
-  {% set full_refresh_mode = flags.FULL_REFRESH %}
+  {% set full_refresh_mode = (should_full_refresh()) %}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}
@@ -9,19 +9,19 @@
   {{ run_hooks(pre_hooks) }}
 
   {% if existing_relation is none %}
-      {% set build_sql = dbt_labs_experimental_features.create_materialized_view_as(target_relation, sql, config) %}
+      {% set build_sql = dbt_labs_materialized_views.create_materialized_view_as(target_relation, sql, config) %}
   {% elif existing_relation.is_view or existing_relation.is_table %}
       {#-- Can't overwrite a view with a table - we must drop --#}
       {{ log("Dropping relation " ~ target_relation ~ " because it is a " ~ existing_relation.type ~ " and this model is a materialized view.") }}
       {% do adapter.drop_relation(existing_relation) %}
-      {% set build_sql = dbt_labs_experimental_features.create_materialized_view_as(target_relation, sql, config) %}
+      {% set build_sql = dbt_labs_materialized_views.create_materialized_view_as(target_relation, sql, config) %}
   {% elif full_refresh_mode %}
       {#-- create or replace not yet supported for materialized views --#}
       {{ log("Dropping relation " ~ target_relation ~ " because replacing an existing materialized view is not supported.") }}
       {% do adapter.drop_relation(existing_relation) %}
-      {% set build_sql = dbt_labs_experimental_features.create_materialized_view_as(target_relation, sql, config) %}
+      {% set build_sql = dbt_labs_materialized_views.create_materialized_view_as(target_relation, sql, config) %}
   {% else %}
-      {% set build_sql = dbt_labs_experimental_features.refresh_materialized_view(target_relation, config) %}
+      {% set build_sql = dbt_labs_materialized_views.refresh_materialized_view(target_relation, config) %}
   {% endif %}
 
   {% if build_sql %}
@@ -29,10 +29,12 @@
           {{ build_sql }}
       {% endcall %}
   {% else %}
-    {{ store_result('main', status='SKIP') }}
+    {{ store_result('main', 'SKIP') }}
   {% endif %}
 
   {{ run_hooks(post_hooks) }}
+  
+  {% do persist_docs(target_relation, model) %}
 
   {{ return({'relations': [target_relation]}) }}
 

--- a/materialized-views/macros/default/adapters.sql
+++ b/materialized-views/macros/default/adapters.sql
@@ -1,5 +1,5 @@
 {% macro create_materialized_view_as(relation, sql, config) %}
-    {{ return(adapter_macro('dbt_labs_experimental_features.create_materialized_view_as', relation, sql, config)) }}
+    {{ return(adapter.dispatch('create_materialized_view_as', packages = ['dbt_labs_materialized_views'])(relation, sql, config)) }}
 {% endmacro %}
 
 {% macro default__create_materialized_view_as(relation, sql, config) -%}
@@ -10,9 +10,8 @@
 
 {% endmacro %}
 
-
 {% macro refresh_materialized_view(relation, config) %}
-    {{ return(adapter_macro('dbt_labs_experimental_features.refresh_materialized_view', relation, config)) }}
+    {{ return(adapter.dispatch('refresh_materialized_view', packages = ['dbt_labs_materialized_views'])(relation, config)) }}
 {% endmacro %}
 
 {% macro default__refresh_materialized_view(relation, config) -%}
@@ -21,24 +20,10 @@
 
 {% endmacro %}
 
-
-{% macro drop_materialized_view(relation) %}
-    {{ return(adapter_macro('dbt_labs_experimental_features.drop_materialized_view', relation)) }}
-{% endmacro %}
-
-{% macro default__drop_materialized_view(relation) %}
-
-    drop materialized view if exists {{relation}} cascade
-
-{% endmacro %}
-
-
-
-{% macro is_materialized_view(relation) %}
-    {{ return(adapter_macro('dbt_labs_experimental_features.is_materialized_view', relation)) }}
-{% endmacro %}
-
-{% macro default__is_materialized_view(relation) %}
-    {% set is_matview = (relation.type == 'materialized view') %}
-    {% do return(is_matview) %}
+{# override builtin behavior of adapter.drop_relation #}
+{% macro drop_relation(relation) -%}
+  {% set relation_type = 'materialized view' if relation.type == 'materializedview' else relation.type %}
+  {% call statement('drop_relation', auto_begin=False) -%}
+    drop {{ relation_type }} if exists {{ relation }} cascade
+  {%- endcall %}
 {% endmacro %}

--- a/materialized-views/macros/default/materialized_view.sql
+++ b/materialized-views/macros/default/materialized_view.sql
@@ -1,21 +1,11 @@
 {% materialization materialized_view, default -%}
 
-  {% set full_refresh_mode = flags.FULL_REFRESH %}
+  {% set full_refresh_mode = (should_full_refresh()) %}
 
   {% set target_relation = this %}
   {% set existing_relation = load_relation(this) %}
   {% set tmp_relation = make_temp_relation(this) %}
   
-  {% set is_existing_matview = dbt_labs_experimental_features.is_materialized_view(this) %}
-  {% if is_existing_matview %}
-      {% set existing_relation = api.Relation.create(
-          database = this.database,
-          schema = this.schema,
-          identifier = this.identifier,
-          type = 'materializedview'
-      ) %}
-  {% endif %}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
   -- `BEGIN` happens here:
@@ -24,7 +14,7 @@
   {% set to_drop = [] %}
   
   {% if existing_relation is none %}
-      {% set build_sql = dbt_labs_experimental_features.create_materialized_view_as(target_relation, sql, config) %}
+      {% set build_sql = dbt_labs_materialized_views.create_materialized_view_as(target_relation, sql, config) %}
   
   {% elif full_refresh_mode or existing_relation.type != 'materializedview' %}
       {#-- Make sure the backup doesn't exist so we don't encounter issues with the rename below #}
@@ -33,11 +23,11 @@
       {% do adapter.drop_relation(backup_relation) %}
 
       {% do adapter.rename_relation(target_relation, backup_relation) %}
-      {% set build_sql = dbt_labs_experimental_features.create_materialized_view_as(target_relation, sql, config) %}
+      {% set build_sql = dbt_labs_materialized_views.create_materialized_view_as(target_relation, sql, config) %}
       {% do to_drop.append(backup_relation) %}
   
   {% else %}
-      {% set build_sql = dbt_labs_experimental_features.refresh_materialized_view(target_relation, config) %}
+      {% set build_sql = dbt_labs_materialized_views.refresh_materialized_view(target_relation, config) %}
   {% endif %}
 
   {% call statement("main") %}
@@ -45,6 +35,8 @@
   {% endcall %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
+  
+  {% do persist_docs(target_relation, model) %}
 
   -- `COMMIT` happens here
   {% do adapter.commit() %}

--- a/materialized-views/macros/postgres/adapters.sql
+++ b/materialized-views/macros/postgres/adapters.sql
@@ -1,31 +1,106 @@
-{% macro postgres__is_materialized_view(relation) %}
+{% macro postgres__list_relations_without_caching(schema_relation) %}
+  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+    select
+      '{{ schema_relation.database }}' as database,
+      tablename as name,
+      schemaname as schema,
+      'table' as type
+    from pg_tables
+    where schemaname ilike '{{ schema_relation.schema }}'
+    union all
+    select
+      '{{ schema_relation.database }}' as database,
+      viewname as name,
+      schemaname as schema,
+      'view' as type
+    from pg_views
+    where schemaname ilike '{{ schema_relation.schema }}'
+    union all
+    select
+        '{{ schema_relation.database }}' as database,
+        matviewname as name,
+        schemaname as schema,
+        'materializedview' as type
+    from pg_matviews
+    where schemaname ilike '{{ schema_relation.schema }}'
+  {% endcall %}
+  {{ return(load_result('list_relations_without_caching').table) }}
+{% endmacro %}
 
-    {% set existing_relation = load_relation(this) %}
-    
-    {# materialized views don't appear in pg_tables or pg_views #}
-    {% if existing_relation is none %}
 
-        {% set find_matview %}
-        
-            select count(*) from pg_matviews
-            where schemaname = '{{relation.schema}}'
-            and matviewname = '{{relation.identifier}}'
-        
-        {% endset %}
-        
-        {% if execute %}
-            {% set result = run_query(find_matview)[0][0] %}
-        {% else %}
-            {% set result = 0 %}
-        {% endif %}
+{% macro postgres_get_relations () -%}
 
-        {% set is_matview = (result > 0) %}
-        {% do return(is_matview) %}
-        
-    {% else %}
-    
-        {% do return(false) %}
-        
-    {% endif %}
+  {#
+      -- in pg_depend, objid is the dependent, refobjid is the referenced object
+      --  > a pg_depend entry indicates that the referenced object cannot be
+      --  > dropped without also dropping the dependent object.
+  #}
 
+  {%- call statement('relations', fetch_result=True) -%}
+    with relation as (
+        select
+            pg_rewrite.ev_class as class,
+            pg_rewrite.oid as id
+        from pg_rewrite
+    ),
+    class as (
+        select
+            oid as id,
+            relname as name,
+            relnamespace as schema,
+            relkind as kind
+        from pg_class
+    ),
+    dependency as (
+        select
+            pg_depend.objid as id,
+            pg_depend.refobjid as ref
+        from pg_depend
+    ),
+    schema as (
+        select
+            pg_namespace.oid as id,
+            pg_namespace.nspname as name
+        from pg_namespace
+        where nspname != 'information_schema' and nspname not like 'pg\_%'
+    ),
+    referenced as (
+        select
+            relation.id AS id,
+            referenced_class.name ,
+            referenced_class.schema ,
+            referenced_class.kind
+        from relation
+        join class as referenced_class on relation.class=referenced_class.id
+        where referenced_class.kind in ('r', 'v', 'm')
+    ),
+    relationships as (
+        select
+            referenced.name as referenced_name,
+            referenced.schema as referenced_schema_id,
+            dependent_class.name as dependent_name,
+            dependent_class.schema as dependent_schema_id,
+            referenced.kind as kind
+        from referenced
+        join dependency on referenced.id=dependency.id
+        join class as dependent_class on dependency.ref=dependent_class.id
+        where
+            (referenced.name != dependent_class.name or
+             referenced.schema != dependent_class.schema)
+    )
+
+    select
+        referenced_schema.name as referenced_schema,
+        relationships.referenced_name as referenced_name,
+        dependent_schema.name as dependent_schema,
+        relationships.dependent_name as dependent_name
+    from relationships
+    join schema as dependent_schema on relationships.dependent_schema_id=dependent_schema.id
+    join schema as referenced_schema on relationships.referenced_schema_id=referenced_schema.id
+    group by referenced_schema, referenced_name, dependent_schema, dependent_name
+    order by referenced_schema, referenced_name, dependent_schema, dependent_name;
+
+  {%- endcall -%}
+
+  {{ return(load_result('relations').table) }}
 {% endmacro %}

--- a/materialized-views/macros/snowflake/adapters.sql
+++ b/materialized-views/macros/snowflake/adapters.sql
@@ -2,8 +2,6 @@
     {%- set secure = config.get('secure', default=false) -%}
     {%- set cluster_by_keys = config.get('cluster_by', default=none) -%}
     {%- set enable_automatic_clustering = config.get('automatic_clustering', default=false) -%}
-    {%- set raw_persist_docs = config.get('persist_docs', {}) -%}
-    {%- set relation_comment = get_relation_comment(raw_persist_docs, model) -%}
     {%- set sql_header = config.get('sql_header', none) -%}
 
     {%- if cluster_by_keys is not none and cluster_by_keys is string -%}
@@ -20,7 +18,6 @@
     create or replace 
         {% if secure -%} secure {%- endif %} 
         materialized view {{relation}}
-        {% if relation_comment is not none -%} comment = '{{relation_comment}}' {% endif %}
     as (
         {{sql}}
     );
@@ -33,4 +30,3 @@
     {%- endif -%}
 
 {% endmacro %}
-


### PR DESCRIPTION
### Materialized Views

Nine months later!

- Upgrade all materializations to use features in latest versions of dbt (`>=0.18.0`):
    - `adapter.dispatch()`
    - `should_full_refresh()`
    - `persist_docs()`
- Reimplement on Postgres and Redshift. Rather than one-off `is_materialized_view` macro called from materialization, actually account for materialized views within dbt by overriding adapter/plugin macros: `drop_relation()`, `list_relations_without_caching()`, `postgres_get_relations()`. These are the macros we'd want to update if/when we eventually upstream this code to live within dbt core/plugins.
- Standardize `auto_refresh` config on Redshift + BigQuery

### Repo cleanup
- Add dedicated README for Materialized Views project. Update main README. Link to [`dbt-materialize`](https://github.com/MaterializeInc/dbt-materialize) in both :)
- Add license (Apache 2.0)