### PR TITLE
Updates config-version param in dbt_profiles to be compatible with dbt 0.19

### DIFF
--- a/bq-incrementals/dbt_project.yml
+++ b/bq-incrementals/dbt_project.yml
@@ -1,6 +1,7 @@
 
 name: 'bq_incremental_testing'
 version: '0.1.0'
+config-version: 2
 
 profile: 'garage-bigquery'
 

--- a/lambda-views/dbt_project.yml
+++ b/lambda-views/dbt_project.yml
@@ -1,5 +1,6 @@
 name: 'lambda_views'
 version: '0.1.0'
+config-version: 2
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]

--- a/materialized-views/dbt_project.yml
+++ b/materialized-views/dbt_project.yml
@@ -1,5 +1,6 @@
 name: 'dbt_labs_experimental_features'
 version: '0.1.0'
+config-version: 2
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]


### PR DESCRIPTION
I recent went to upgrade to the latest DBT release and found that it yells about the config version in the materialized view package.  This upgrades the other two that were not as well, curiously the redshift masking package was already updated.

Thought this would go well with the work you're doing in that other PR, cheers.