### PR TITLE
Updating adapters.sql for DBT 1.0

### DIFF
--- a/materialized-views/macros/default/adapters.sql
+++ b/materialized-views/macros/default/adapters.sql
@@ -1,5 +1,5 @@
 {% macro create_materialized_view_as(relation, sql, config) %}
-    {{ return(adapter.dispatch('create_materialized_view_as', packages = ['dbt_labs_materialized_views'])(relation, sql, config)) }}
+    {{ return(adapter.dispatch('create_materialized_view_as', macro_namespace = 'dbt_labs_materialized_views')(relation, sql, config)) }}
 {% endmacro %}
 
 {% macro default__create_materialized_view_as(relation, sql, config) -%}
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 {% macro refresh_materialized_view(relation, config) %}
-    {{ return(adapter.dispatch('refresh_materialized_view', packages = ['dbt_labs_materialized_views'])(relation, config)) }}
+    {{ return(adapter.dispatch('refresh_materialized_view', macro_namespace = 'dbt_labs_materialized_views')(relation, config)) }}
 {% endmacro %}
 
 {% macro default__refresh_materialized_view(relation, config) -%}


### PR DESCRIPTION
Hi there, this fixes an error that appeared with the DBT 1.0 release.

```
...22:07:36  Compilation Error in model ...
22:07:36        The "packages" argument of adapter.dispatch() has been deprecated.
22:07:36        Use the "macro_namespace" argument instead.
22:07:36    
22:07:36        Raised during dispatch for: create_materialized_view_as
22:07:36    
22:07:36        For more information, see:
22:07:36    
22:07:36        https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch
22:07:36        
22:07:36    
22:07:36    > in macro create_materialized_view_as (macros/default/adapters.sql)
22:07:36    > called by macro materialization_materialized_view_bigquery (macros/bigquery/materialized_view.sql)
```